### PR TITLE
Add option to only block scroll when item is scrollable

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@
 
       <p>With isolated-scroll:</p>
 
-      <div id="isolated-scroll" class="container">
+      <div id="always-isolated-scroll" class="container">
         <ul>
           <li>List item.</li>
           <li>List item.</li>
@@ -107,6 +107,18 @@
           <li>List item.</li>
           <li>List item.</li>
           <li>List item.</li>
+          <li>List item.</li>
+          <li>List item.</li>
+          <li>List item.</li>
+          <li>List item.</li>
+          <li>List item.</li>
+        </ul>
+      </div>
+
+      <p>With isolated-scroll (but element isn't scrollable):</p>
+
+      <div id="isolated-scroll" class="container">
+        <ul>
           <li>List item.</li>
           <li>List item.</li>
           <li>List item.</li>

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,5 +2,8 @@ require('./index.html');
 
 import isolatedScroll from '../src';
 
-const el = document.getElementById('isolated-scroll');
-isolatedScroll(el);
+const el = document.getElementById('always-isolated-scroll');
+isolatedScroll(el, false);
+
+const el2 = document.getElementById('isolated-scroll');
+isolatedScroll(el2, true);

--- a/src/index.js
+++ b/src/index.js
@@ -8,32 +8,36 @@ const calculateHeight = el => {
 };
 
 // Source adapted from: http://stackoverflow.com/a/16324762
-const makeHandler = el => event => {
-  const { scrollTop, scrollHeight } = el;
+const makeHandler = (el, onlyWhenScrollable) => event => {
+  const { scrollTop, scrollHeight, clientHeight } = el;
   const { type, detail, wheelDelta } = event;
-  const height = calculateHeight(el);
-  const delta = (type === 'DOMMouseScroll' ? detail * -40 : wheelDelta);
-  const up = delta > 0;
+  const isScrollable = scrollHeight > clientHeight;
 
-  const prevent = () => {
-    event.stopPropagation();
-    event.preventDefault();
-    event.returnValue = false;
+  if (!onlyWhenScrollable || isScrollable) {
+    const height = calculateHeight(el);
+    const delta = (type === 'DOMMouseScroll' ? detail * -40 : wheelDelta);
+    const up = delta > 0;
 
-    return false;
-  };
+    const prevent = () => {
+      event.stopPropagation();
+      event.preventDefault();
+      event.returnValue = false;
 
-  if (!up && -delta > scrollHeight - height - scrollTop) {
-    el.scrollTop = scrollHeight;
-    return prevent();
-  } else if (up && delta > scrollTop) {
-    el.scrollTop = 0;
-    return prevent();
+      return false;
+    };
+
+    if (!up && -delta > scrollHeight - height - scrollTop) {
+      el.scrollTop = scrollHeight;
+      return prevent();
+    } else if (up && delta > scrollTop) {
+      el.scrollTop = 0;
+      return prevent();
+    }
   }
 };
 
-export default el => {
-  const handler = makeHandler(el);
+export default (el, onlyWhenScrollable) => {
+  const handler = makeHandler(el, onlyWhenScrollable);
 
   const addEvent = (el.addEventListener || el.attachEvent).bind(el);
   const removeEvent = (el.removeEventListener || el.detachEvent).bind(el);


### PR DESCRIPTION
Solves #1 

This adds an option for a small check to see if the element is in a scrollable state before blocking. 
